### PR TITLE
Migrate to play 2.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,9 +8,9 @@ scalaVersion := "2.10.1"
 
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
-libraryDependencies += "play" %% "play" % "2.1.1"
+libraryDependencies += "com.typesafe.play" %% "play" % "2.2.0"
 
-libraryDependencies += "play" %% "play-test" % "2.1.1" % "test"
+libraryDependencies += "com.typesafe.play" %% "play-test" % "2.2.0" % "test"
 
 publishTo <<= version {
   case v if v.trim.endsWith("SNAPSHOT") => Some(Resolver.file("Github Pages", Path.userHome / "sites" / "julienrf.github.com" / "repo-snapshots" asFile))


### PR DESCRIPTION
Thanks for sharing this filter - one of very few examples showing how to modify the result stream.

I'm working with Play 2.2 and the code you supply didn't work out of the box due to the new Result structure. This pull request works for me.
