### PR TITLE
Migration to Play 2.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .idea_modules/
 target/
 *.iml
+.cache
+.classpath
+.project

--- a/build.sbt
+++ b/build.sbt
@@ -4,13 +4,18 @@ organization := "julienrf"
 
 version := "1.1-SNAPSHOT"
 
-scalaVersion := "2.10.2"
+scalaVersion := "2.11.1"
+
+crossScalaVersions := Seq("2.10.4", "2.11.1")
 
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
-libraryDependencies += "com.typesafe.play" %% "play" % "[2.2.0,)"
+val playVersion = "2.3.0"
 
-libraryDependencies += "com.typesafe.play" %% "play-test" % "[2.2.0,)" % "test"
+libraryDependencies ++= Seq(
+  "com.typesafe.play" %% "play" % playVersion,
+  "com.typesafe.play" %% "play-test" % playVersion % "test"
+)
 
 lazy val sitePath = settingKey[File]("Path to the publishing site")
 

--- a/src/main/scala/julienrf/play/jsonp/Jsonp.scala
+++ b/src/main/scala/julienrf/play/jsonp/Jsonp.scala
@@ -15,7 +15,7 @@ import play.api.libs.iteratee.Enumerator
  * @param codec Codec used to serialize the response body
  * @param ex Execution context to use in case of asynchronous results
  */
-class Jsonp(paramName: String = "callback")(implicit codec: Codec, ex: ExecutionContext) extends EssentialFilter {
+class Jsonp(paramName: String = Jsonp.DefaultParamName)(implicit codec: Codec, ex: ExecutionContext) extends EssentialFilter {
 
   def apply(action: EssentialAction) = EssentialAction { request =>
     val resultProducer = action(request)
@@ -30,10 +30,10 @@ class Jsonp(paramName: String = "callback")(implicit codec: Codec, ex: Execution
    * @param callback JavaScript callback name
    * @param result Result to transform
    */
-  def jsonpify(callback: String)(result: SimpleResult): SimpleResult = 
+  def jsonpify(callback: String)(result: Result): Result = 
     result.header.headers.get(CONTENT_TYPE) match {
       case Some(ct) if ct == JSON =>
-        SimpleResult(
+        Result(
           header = result.header,
           body = Enumerator(codec.encode(s"$callback(")) >>> result.body >>> Enumerator(codec.encode(");")),
           connection = result.connection
@@ -41,4 +41,8 @@ class Jsonp(paramName: String = "callback")(implicit codec: Codec, ex: Execution
       case _ => result
     }
 
+}
+
+object Jsonp {
+  val DefaultParamName = "callback";
 }

--- a/src/main/scala/julienrf/play/jsonp/JsonpJava.scala
+++ b/src/main/scala/julienrf/play/jsonp/JsonpJava.scala
@@ -1,0 +1,8 @@
+package julienrf.play.jsonp
+
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import play.api.mvc.Codec.utf_8
+
+class JsonpJava extends Jsonp(Jsonp.DefaultParamName)(utf_8, defaultContext) {
+
+}

--- a/src/test/scala/julienrf/play/jsonp/JsonpSpec.scala
+++ b/src/test/scala/julienrf/play/jsonp/JsonpSpec.scala
@@ -1,7 +1,7 @@
 package julienrf.play.jsonp
 
 import org.specs2.mutable.Specification
-import play.api.mvc.{SimpleResult, Result, EssentialAction}
+import play.api.mvc.{Result, EssentialAction}
 import play.api.mvc.Codec.utf_8
 import play.api.mvc.Results.Ok
 import play.api.test.FakeRequest
@@ -22,7 +22,7 @@ object JsonpSpec extends Specification {
 
     val jsonAction = EssentialAction(_ => Done(Ok(Json.obj("bar" -> "baz"))))
 
-    def run(uri: String)(action: EssentialAction): Future[SimpleResult] =
+    def run(uri: String)(action: EssentialAction): Future[Result] =
       filter(action)(FakeRequest("GET", uri)).run
 
     "leave non-JSON results untouched" in {


### PR DESCRIPTION
Change Scala and Play versions
Use play.api.mvc.Result instead of SimpleResult
Add special class with no args constructor to support Java
